### PR TITLE
git/clone.sh でコミットに失敗する

### DIFF
--- a/build/build-product.sh
+++ b/build/build-product.sh
@@ -14,7 +14,7 @@ cd "$(cd ${dir_script}; cd ..; pwd)" || exit 6
 readonly BUILD_PROFILE="product"
 
 readonly SONAR_URL="https://sonarcloud.io"
-readonly SONAR_ORGANIZATION="suwa-sh-github"
+readonly SONAR_ORGANIZATION="in-house-swagger"
 readonly SONAR_EXCLUDES="src/test/**,src/main/java/io/**,**/gen/**,**/*Exception.java,**/ws/infra/*Filter.java"
 
 readonly DIR_BASE="$(pwd)"
@@ -56,6 +56,7 @@ if [[ "${SONAR_TOKEN}x" = "x" ]]; then
     -P ${BUILD_PROFILE}                                                                            \
 
 else
+  echo "SONAR_TOKEN が定義されています。sonar解析を実施します。"
   mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar                       \
     -P ${BUILD_PROFILE}                                                                            \
     -Dsonar.host.url=${SONAR_URL}                                                                  \

--- a/docs/design/webapi/swagger.yaml
+++ b/docs/design/webapi/swagger.yaml
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
   description: "Swagger Specification Management APIs. "
-  version: "0.7.0"
+  version: "0.7.1"
   title: "Swagger Specification Manager"
   contact:
     name: "suwa-sh"

--- a/docs/manual/webapi/index.html
+++ b/docs/manual/webapi/index.html
@@ -489,7 +489,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="sect2">
 <h3 id="_version_information">Version information</h3>
 <div class="paragraph">
-<p><em>Version</em> : 0.7.0</p>
+<p><em>Version</em> : 0.7.1</p>
 </div>
 </div>
 <div class="sect2">
@@ -3414,7 +3414,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-10-31 09:57:35 JST
+Last updated 2017-11-22 09:55:30 JST
 </div>
 </div>
 </body>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>swagger-spec-mgr</artifactId>
     <packaging>jar</packaging>
     <name>swagger-spec-mgr</name>
-    <version>0.7.0</version>
+    <version>0.7.1</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/src/main/scripts/bin/git/clone.sh
+++ b/src/main/scripts/bin/git/clone.sh
@@ -65,12 +65,6 @@ function local.init() {
     return ${EXITCODE_ERROR}
   fi
 
-  # first commit (empty)
-  git.commit "${_dir_repo}" "first commit" "--allow-empty"
-  if [ $? -ne ${EXITCODE_SUCCESS} ]; then
-    return ${EXITCODE_ERROR}
-  fi
-
   return ${EXITCODE_SUCCESS}
 }
 
@@ -246,4 +240,13 @@ fi
 #--------------------------------------------------------------------------------------------------
 # 事後処理
 #--------------------------------------------------------------------------------------------------
+if [ "${GIT_REMOTE_REPOSITORY_URL}x" = "x" ]; then
+  # first commit (empty)
+  git.commit "${dir_repo}" "first commit" "--allow-empty"                                     2>&1 | log.tee
+  ret_code=${PIPESTATUS[0]}
+  if [ ${ret_code} -ne ${EXITCODE_SUCCESS} ]; then
+    git.common.exit_script ${EXITCODE_ERROR} "初期コミットの追加でエラーが発生しました。"
+  fi
+fi
+
 git.common.exit_script ${EXITCODE_SUCCESS} "${EXITMSG_SUCCESS}"

--- a/src/test/java/me/suwash/swagger/spec/manager/sv/service/UserServiceTest.java
+++ b/src/test/java/me/suwash/swagger/spec/manager/sv/service/UserServiceTest.java
@@ -107,6 +107,9 @@ public class UserServiceTest {
     }
 
     // 作成済み
+    if (service.idList().contains("error")) {
+      service.deleteUser("error");
+    }
     service.addUser("error", "error@test.com");
     try {
       service.addUser("error", "error@test.com");

--- a/src/test/java/me/suwash/swagger/spec/manager/ws/api/TagsApiControllerTest.java
+++ b/src/test/java/me/suwash/swagger/spec/manager/ws/api/TagsApiControllerTest.java
@@ -4,6 +4,7 @@ import static me.suwash.swagger.spec.manager.ws.api.ControllerTestUtils.withComm
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -77,7 +78,7 @@ public class TagsApiControllerTest {
     CommitInfo commitInfo =
         new CommitInfo(COMMIT_USER, COMMIT_USER + "@example.com", COMMIT_USER + " test tag.");
     RequestMediaType requestMediaType = RequestMediaType.json;
-    FileUtils.rmdirs(DIR_DATA);
+    if(!FileUtils.rmdirs(DIR_DATA)) fail(DIR_DATA + " を初期化できません。");
 
     // -----------------------------------------------------------------------------------------
     // 準備


### PR DESCRIPTION
spec-mgr側の修正内容です。

一旦 v0.7.0の配布アーカイブを、対応版で差し替えてありますが
ちゃんと対応したほうが良さそうなので
これがマージされたら、in-house-swagger側の利用バージョン指定も更新しようかと思いますー

### 対応内容
* #30 git/clone.sh でコミットに失敗する
* SonarCloudのプロジェクトをin-house-swaggerグループに引越し
* 不安定だったUTをブラッシュアップ

